### PR TITLE
Convert interface to builder mode (breaking change)

### DIFF
--- a/src/pipelines/stable_diffusion/callback-approximate-image.md
+++ b/src/pipelines/stable_diffusion/callback-approximate-image.md
@@ -3,21 +3,21 @@ visually. This is lower quality than [`StableDiffusionCallback::Decoded`] but mu
 
 Approximated images may be noisy and colors will not be accurate (especially if using a fine-tuned VAE).
 
-## Function Parameters:
+## Callback Parameters:
 
 - **`step`** (usize): The current step number.
 - **`timestep`** (f32): This step's timestep.
 - **`image`** (`Vec<DynamicImage>`): Vector of approximated decoded images for this step.
 
-## Function Return
+## Callback Return
 
 - **bool**: whether rendering should be stopped
 
-## Function Example
+## Callback Example
 
 ```no_run
 let mut images = Vec::new();
-let callback_approximate_image = move |_: usize, _: f32, image: Vec<DynamicImage>| -> bool {
+let callback = move |_: usize, _: f32, image: Vec<DynamicImage>| -> bool {
     images.extend(image);
     true
 };

--- a/src/pipelines/stable_diffusion/callback-approximate-image.md
+++ b/src/pipelines/stable_diffusion/callback-approximate-image.md
@@ -1,0 +1,24 @@
+A callback to receive this step's approximately decoded latents, to be used for e.g. showing image progress
+visually. This is lower quality than [`StableDiffusionCallback::Decoded`] but much faster.
+
+Approximated images may be noisy and colors will not be accurate (especially if using a fine-tuned VAE).
+
+## Function Parameters:
+
+- **`step`** (usize): The current step number.
+- **`timestep`** (f32): This step's timestep.
+- **`image`** (`Vec<DynamicImage>`): Vector of approximated decoded images for this step.
+
+## Function Return
+
+- **bool**: whether rendering should be stopped
+
+## Function Example
+
+```no_run
+let mut images = Vec::new();
+let callback_approximate_image = move |_: usize, _: f32, image: Vec<DynamicImage>| -> bool {
+    images.extend(image);
+    true
+};
+```

--- a/src/pipelines/stable_diffusion/callback-decode-image.md
+++ b/src/pipelines/stable_diffusion/callback-decode-image.md
@@ -1,0 +1,23 @@
+A callback to receive this step's fully decoded latents, to be used for e.g. showing image progress visually.
+This is very expensive, as it will execute the VAE decoder on each call. See
+[`StableDiffusionCallback::ApproximateDecoded`] for an approximated version.
+
+## Callback Parameters:
+
+- **`step`** (usize): The current step number.
+- **`timestep`** (f32): This step's timestep.
+- **`image`** (`Vec<DynamicImage>`): Vector of decoded images for this step.
+
+## Callback Return
+
+- **bool**: whether rendering should be stopped
+
+## Callback Example
+
+```no_run
+let mut images = Vec::new();
+let callback = move |_: usize, _: f32, image: Vec<DynamicImage>| -> bool {
+    images.extend(image);
+    true
+};
+```

--- a/src/pipelines/stable_diffusion/callback-latents.md
+++ b/src/pipelines/stable_diffusion/callback-latents.md
@@ -1,0 +1,21 @@
+A callback to receive this step's latents.
+
+## Callback Parameters:
+
+- **`step`** (usize): The current step number.
+- **`timestep`** (f32): This step's timestep.
+- **`latents`** (`Array4<f32>`): Scheduler latent outputs for this step.
+
+## Callback Return
+
+- **bool**: whether rendering should be stopped
+
+## Callback Example
+
+```no_run
+let all = 50;
+let callback = move |step: usize, _: f32, _: Array4<f32>| -> bool {
+    println!("Progress: {}%", step as f32 / all as f32 * 100.0);
+    true
+};
+```

--- a/src/pipelines/stable_diffusion/callback-progress.md
+++ b/src/pipelines/stable_diffusion/callback-progress.md
@@ -1,0 +1,20 @@
+A simple callback to be used for e.g. reporting progress updates.
+
+## Callback Parameters:
+
+- **`step`** (usize): The current step number.
+- **`timestep`** (f32): This step's timestep.
+
+## Callback Return
+
+- **bool**: whether rendering should be stopped
+
+## Callback Example
+
+```no_run
+let all = 50;
+let callback = move |step: usize, _: f32| -> bool {
+    println!("Progress: {}%", step as f32 / all as f32 * 100.0);
+    true
+};
+```

--- a/src/pipelines/stable_diffusion/impl_img2img.rs
+++ b/src/pipelines/stable_diffusion/impl_img2img.rs
@@ -1,4 +1,8 @@
-use crate::{ImagePreprocessing, StableDiffusionImg2ImgOptions, StableDiffusionTxt2ImgOptions};
+use image::imageops::FilterType;
+use image::{DynamicImage, Rgb32FImage};
+use ndarray::Array4;
+
+use crate::{ImagePreprocessing, Prompt, StableDiffusionCallback, StableDiffusionImg2ImgOptions, StableDiffusionTxt2ImgOptions};
 
 impl Default for StableDiffusionImg2ImgOptions {
 	fn default() -> Self {
@@ -13,68 +17,115 @@ impl Default for StableDiffusionImg2ImgOptions {
 }
 
 // builder for options
-impl StableDiffusionTxt2ImgOptions {
+impl StableDiffusionImg2ImgOptions {
 	///  Set the size of the image. **Must be divisible by 8.**
-	pub fn with_size(self, height: u32, width: u32) -> OrtResult<Self> {
+	pub fn with_size(self, height: u32, width: u32) -> anyhow::Result<Self> {
 		self.with_width(width)?.with_height(height)
 	}
 	///  Set the width of the image. **Must be divisible by 8.**
-	pub fn with_width(mut self, width: u32) -> OrtResult<Self> {
-		if width % 8 != 0 || width.is_zero() {
-			Err(OrtError::DataTypeMismatch {
-				actual: TensorElementDataType::Float32,
-				requested: TensorElementDataType::Float32
-			})?
+	pub fn with_width(mut self, width: u32) -> anyhow::Result<Self> {
+		if width % 8 != 0 || width == 0 {
+			anyhow::bail!("width must be positive integer that divisible by 8")
 		}
-		self.width = width;
+		self.target_width = width;
+		self.drop_reference_image();
 		Ok(self)
 	}
 	///  Set the height of the image. **Must be divisible by 8.**
-	pub fn with_height(mut self, height: u32) -> OrtResult<Self> {
-		if height % 8 != 0 || height.is_zero() {
-			Err(OrtError::DataTypeMismatch {
-				actual: TensorElementDataType::Float32,
-				requested: TensorElementDataType::Float32
-			})?
+	pub fn with_height(mut self, height: u32) -> anyhow::Result<Self> {
+		if height % 8 != 0 || height == 0 {
+			anyhow::bail!("height must be positive integer that divisible by 8")
 		}
-		self.height = height;
+		self.target_height = height;
+		self.drop_reference_image();
 		Ok(self)
 	}
-	/// Set the number of steps to take to generate the image. More steps typically yields higher quality images.
+	#[inline(always)]
+	fn drop_reference_image(&mut self) {
+		self.reference_image = Array4::default((1, 1, 1, 1));
+	}
+	/// The number of steps to take to generate the image. More steps typically yields higher quality images.
 	pub fn with_steps(mut self, steps: usize) -> Self {
-		self.steps = steps;
+		self.text_config.steps = steps;
 		self
 	}
-	/// Set the prompt(s) to use when generating the image. Typically used to produce classifier-free guidance.
+	/// Set the prompt(s) to use when generating the image.
 	pub fn with_prompts<P, N>(mut self, positive_prompt: P, negative_prompt: Option<N>) -> Self
 	where
 		P: Into<Prompt>,
 		N: Into<Prompt>
 	{
-		self.positive_prompt = positive_prompt.into();
-		self.negative_prompt = negative_prompt.map(|p| p.into());
+		self.text_config.positive_prompt = positive_prompt.into();
+		self.text_config.negative_prompt = negative_prompt.map(|p| p.into());
 		self
 	}
-	/// Set the seed to use when first generating noise. The same seed with the same scheduler, prompt, & guidance
+	/// Set with given seed, so that each run generates the same image.
 	pub fn with_seed(mut self, seed: u64) -> Self {
-		self.seed = Some(seed);
+		self.text_config.seed = Some(seed);
 		self
 	}
-	/// Set the scale of the guidance. Higher values will result in more guidance, lower values will result in less.
-	pub fn with_guidance_scale(mut self, guidance_scale: f32) -> Self {
-		self.guidance_scale = guidance_scale;
+	/// Use a random seed, so that each run generates a different image.
+	pub fn with_random_seed(mut self) -> Self {
+		self.text_config.seed = None;
 		self
+	}
+	/// The 'guidance scale' for classifier-free guidance. A lower guidance scale gives the model more freedom, but the
+	/// output may not match the prompt. A higher guidance scale mean the model will match the prompt(s) more strictly,
+	/// but may introduce artifacts; `7.5` is a good balance.
+	pub fn with_guidance_scale(mut self, guidance_scale: f32) -> Self {
+		self.text_config.guidance_scale = guidance_scale;
+		self
+	}
+	/// Set a reference image to for generating
+	pub fn with_image(mut self, image: &DynamicImage, batch: usize) -> Self {
+		// whc -> nchw
+		let image = self.img_norm(image);
+		let shape = [batch, 3, self.target_height as usize, self.target_width as usize];
+		self.reference_image = Array4::from_shape_fn(shape, |(_, w, h, c)| {
+			let pixel = image.get_pixel(h as u32, w as u32);
+			match c {
+				0 => pixel.0[0],
+				1 => pixel.0[1],
+				2 => pixel.0[2],
+				_ => unreachable!()
+			}
+		});
+		self
+	}
+	/// Set reference images to for generating, batch size must be equal to `images.len()`
+	pub fn with_images(mut self, images: &[DynamicImage]) -> Self {
+		// nwhc -> nchw
+		let images = images.iter().map(|image| self.img_norm(image)).collect::<Vec<_>>();
+		let shape = [images.len(), 3, self.target_height as usize, self.target_width as usize];
+		self.reference_image = Array4::from_shape_fn(shape, |(n, w, h, c)| {
+			let pixel = images[n].get_pixel(h as u32, w as u32);
+			match c {
+				0 => pixel.0[0],
+				1 => pixel.0[1],
+				2 => pixel.0[2],
+				_ => unreachable!()
+			}
+		});
+		self
+	}
+	fn img_norm(&self, image: &DynamicImage) -> Rgb32FImage {
+		let img = match self.preprocessing {
+			ImagePreprocessing::Resize => image.resize_exact(self.target_width, self.target_height, FilterType::Lanczos3),
+			ImagePreprocessing::CropFill => image.resize_to_fill(self.target_width, self.target_height, FilterType::Lanczos3)
+		};
+		// normalize to [0, 1]
+		img.to_rgb32f()
 	}
 }
 
 // builder for callbacks
-impl StableDiffusionTxt2ImgOptions {
+impl StableDiffusionImg2ImgOptions {
 	#[doc = include_str!("callback-progress.md")]
 	pub fn callback_progress<F>(mut self, frequency: usize, callback: F) -> Self
 	where
 		F: Fn(usize, f32) -> bool + 'static
 	{
-		self.callback = Some(StableDiffusionCallback::Progress { frequency, cb: Box::new(callback) });
+		self.text_config.callback = Some(StableDiffusionCallback::Progress { frequency, cb: Box::new(callback) });
 		self
 	}
 	#[doc = include_str!("callback-latents.md")]
@@ -82,7 +133,7 @@ impl StableDiffusionTxt2ImgOptions {
 	where
 		F: Fn(usize, f32, Array4<f32>) -> bool + 'static
 	{
-		self.callback = Some(StableDiffusionCallback::Latents { frequency, cb: Box::new(callback) });
+		self.text_config.callback = Some(StableDiffusionCallback::Latents { frequency, cb: Box::new(callback) });
 		self
 	}
 	#[doc = include_str!("callback-decode-image.md")]
@@ -90,7 +141,7 @@ impl StableDiffusionTxt2ImgOptions {
 	where
 		F: Fn(usize, f32, Vec<DynamicImage>) -> bool + 'static
 	{
-		self.callback = Some(StableDiffusionCallback::Decoded { frequency, cb: Box::new(callback) });
+		self.text_config.callback = Some(StableDiffusionCallback::Decoded { frequency, cb: Box::new(callback) });
 		self
 	}
 	#[doc = include_str!("callback-approximate-image.md")]
@@ -98,7 +149,7 @@ impl StableDiffusionTxt2ImgOptions {
 	where
 		F: Fn(usize, f32, Vec<DynamicImage>) -> bool + 'static
 	{
-		self.callback = Some(StableDiffusionCallback::ApproximateDecoded { frequency, cb: Box::new(callback) });
+		self.text_config.callback = Some(StableDiffusionCallback::ApproximateDecoded { frequency, cb: Box::new(callback) });
 		self
 	}
 }

--- a/src/pipelines/stable_diffusion/impl_img2img.rs
+++ b/src/pipelines/stable_diffusion/impl_img2img.rs
@@ -1,0 +1,15 @@
+use crate::{ImagePreprocessing, StableDiffusionImg2ImgOptions, StableDiffusionTxt2ImgOptions};
+
+impl Default for StableDiffusionImg2ImgOptions {
+	fn default() -> Self {
+		Self {
+			reference_image: Default::default(),
+			preprocessing: ImagePreprocessing::CropFill,
+			target_height: 512,
+			target_width: 512,
+			text_config: StableDiffusionTxt2ImgOptions::default()
+		}
+	}
+}
+
+impl StableDiffusionImg2ImgOptions {}

--- a/src/pipelines/stable_diffusion/impl_img2img.rs
+++ b/src/pipelines/stable_diffusion/impl_img2img.rs
@@ -12,4 +12,93 @@ impl Default for StableDiffusionImg2ImgOptions {
 	}
 }
 
-impl StableDiffusionImg2ImgOptions {}
+// builder for options
+impl StableDiffusionTxt2ImgOptions {
+	///  Set the size of the image. **Must be divisible by 8.**
+	pub fn with_size(self, height: u32, width: u32) -> OrtResult<Self> {
+		self.with_width(width)?.with_height(height)
+	}
+	///  Set the width of the image. **Must be divisible by 8.**
+	pub fn with_width(mut self, width: u32) -> OrtResult<Self> {
+		if width % 8 != 0 || width.is_zero() {
+			Err(OrtError::DataTypeMismatch {
+				actual: TensorElementDataType::Float32,
+				requested: TensorElementDataType::Float32
+			})?
+		}
+		self.width = width;
+		Ok(self)
+	}
+	///  Set the height of the image. **Must be divisible by 8.**
+	pub fn with_height(mut self, height: u32) -> OrtResult<Self> {
+		if height % 8 != 0 || height.is_zero() {
+			Err(OrtError::DataTypeMismatch {
+				actual: TensorElementDataType::Float32,
+				requested: TensorElementDataType::Float32
+			})?
+		}
+		self.height = height;
+		Ok(self)
+	}
+	/// Set the number of steps to take to generate the image. More steps typically yields higher quality images.
+	pub fn with_steps(mut self, steps: usize) -> Self {
+		self.steps = steps;
+		self
+	}
+	/// Set the prompt(s) to use when generating the image. Typically used to produce classifier-free guidance.
+	pub fn with_prompts<P, N>(mut self, positive_prompt: P, negative_prompt: Option<N>) -> Self
+	where
+		P: Into<Prompt>,
+		N: Into<Prompt>
+	{
+		self.positive_prompt = positive_prompt.into();
+		self.negative_prompt = negative_prompt.map(|p| p.into());
+		self
+	}
+	/// Set the seed to use when first generating noise. The same seed with the same scheduler, prompt, & guidance
+	pub fn with_seed(mut self, seed: u64) -> Self {
+		self.seed = Some(seed);
+		self
+	}
+	/// Set the scale of the guidance. Higher values will result in more guidance, lower values will result in less.
+	pub fn with_guidance_scale(mut self, guidance_scale: f32) -> Self {
+		self.guidance_scale = guidance_scale;
+		self
+	}
+}
+
+// builder for callbacks
+impl StableDiffusionTxt2ImgOptions {
+	#[doc = include_str!("callback-progress.md")]
+	pub fn callback_progress<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32) -> bool + 'static
+	{
+		self.callback = Some(StableDiffusionCallback::Progress { frequency, cb: Box::new(callback) });
+		self
+	}
+	#[doc = include_str!("callback-latents.md")]
+	pub fn callback_latents<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32, Array4<f32>) -> bool + 'static
+	{
+		self.callback = Some(StableDiffusionCallback::Latents { frequency, cb: Box::new(callback) });
+		self
+	}
+	#[doc = include_str!("callback-decode-image.md")]
+	pub fn callback_decoded<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32, Vec<DynamicImage>) -> bool + 'static
+	{
+		self.callback = Some(StableDiffusionCallback::Decoded { frequency, cb: Box::new(callback) });
+		self
+	}
+	#[doc = include_str!("callback-approximate-image.md")]
+	pub fn callback_approximate<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32, Vec<DynamicImage>) -> bool + 'static
+	{
+		self.callback = Some(StableDiffusionCallback::ApproximateDecoded { frequency, cb: Box::new(callback) });
+		self
+	}
+}

--- a/src/pipelines/stable_diffusion/impl_main.rs
+++ b/src/pipelines/stable_diffusion/impl_main.rs
@@ -60,7 +60,7 @@ pub struct StableDiffusionPipeline {
 	vae_decoder: Session,
 	text_encoder: Session,
 	tokenizer: CLIPStandardTokenizer,
-	unet: Session,
+	pub(crate) unet: Session,
 	safety_checker: Option<Session>,
 	#[allow(dead_code)]
 	feature_extractor: Option<()>

--- a/src/pipelines/stable_diffusion/impl_main.rs
+++ b/src/pipelines/stable_diffusion/impl_main.rs
@@ -16,22 +16,19 @@ use std::path::Path;
 use std::{fs, path::PathBuf, sync::Arc};
 
 use image::{DynamicImage, Rgb32FImage};
-use ndarray::{concatenate, Array1, Array2, Array4, ArrayD, Axis, IxDyn};
+use ndarray::{concatenate, Array2, Array4, ArrayD, Axis, IxDyn};
 use ndarray_einsum_beta::einsum;
-use ndarray_rand::{rand_distr::StandardNormal, RandomExt};
-use num_traits::ToPrimitive;
 use ort::{
 	tensor::{FromArray, InputTensor, OrtOwnedTensor},
 	Environment, OrtResult, Session, SessionBuilder
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
 
 use super::{StableDiffusionOptions, StableDiffusionTxt2ImgOptions};
 use crate::{
 	clip::CLIPStandardTokenizer,
 	config::{DiffusionFramework, DiffusionPipeline, StableDiffusionConfig, TokenizerConfig},
 	schedulers::DiffusionScheduler,
-	Prompt, StableDiffusionCallback
+	Prompt
 };
 
 /// A [Stable Diffusion](https://github.com/CompVis/stable-diffusion) pipeline.
@@ -418,87 +415,15 @@ impl StableDiffusionPipeline {
 	/// # Ok(())
 	/// # }
 	/// ```
+	#[deprecated(note = "use `StableDiffusionTxt2ImgOptions::run` instead")]
 	pub fn txt2img<S: DiffusionScheduler>(
 		&self,
 		prompt: impl Into<Prompt>,
 		scheduler: &mut S,
 		options: StableDiffusionTxt2ImgOptions
 	) -> anyhow::Result<Vec<DynamicImage>> {
-		let steps = options.steps;
-
-		let seed = options.seed.unwrap_or_else(|| rand::thread_rng().gen::<u64>());
-		let mut rng = StdRng::seed_from_u64(seed);
-
-		if options.height % 8 != 0 || options.width % 8 != 0 {
-			anyhow::bail!("`width` ({}) and `height` ({}) must be divisible by 8 for Stable Diffusion", options.width, options.height);
-		}
-
-		let prompt: Prompt = prompt.into();
-		let batch_size = prompt.len();
-
-		let do_classifier_free_guidance = options.guidance_scale > 1.0;
-		let text_embeddings = self.encode_prompt(prompt, do_classifier_free_guidance, options.negative_prompt.as_ref())?;
-
-		let latents_shape = (batch_size, 4_usize, (options.height / 8) as usize, (options.width / 8) as usize);
-		let mut latents = Array4::<f32>::random_using(latents_shape, StandardNormal, &mut rng);
-
-		scheduler.set_timesteps(steps);
-		latents *= scheduler.init_noise_sigma();
-
-		let timesteps = scheduler.timesteps().to_owned();
-		let num_warmup_steps = timesteps.len() - options.steps * S::order();
-
-		for (i, t) in timesteps.to_owned().indexed_iter() {
-			let latent_model_input = if do_classifier_free_guidance {
-				concatenate![Axis(0), latents, latents]
-			} else {
-				latents.to_owned()
-			};
-			let latent_model_input = scheduler.scale_model_input(latent_model_input.view(), *t);
-
-			let latent_model_input: ArrayD<f32> = latent_model_input.into_dyn();
-			let timestep: ArrayD<f32> = Array1::from_iter([t.to_f32().unwrap()]).into_dyn();
-			let encoder_hidden_states: ArrayD<f32> = text_embeddings.clone().into_dyn();
-
-			let noise_pred = self.unet.run(vec![
-				InputTensor::from_array(latent_model_input),
-				InputTensor::from_array(timestep),
-				InputTensor::from_array(encoder_hidden_states),
-			])?;
-			let noise_pred: OrtOwnedTensor<'_, f32, IxDyn> = noise_pred[0].try_extract()?;
-			let noise_pred: Array4<f32> = noise_pred.view().to_owned().into_dimensionality()?;
-
-			let mut noise_pred: Array4<f32> = noise_pred.clone();
-			if do_classifier_free_guidance {
-				let mut noise_pred_chunks = noise_pred.axis_iter(Axis(0));
-				let (noise_pred_uncond, noise_pred_text) = (noise_pred_chunks.next().unwrap(), noise_pred_chunks.next().unwrap());
-				let (noise_pred_uncond, noise_pred_text) = (noise_pred_uncond.insert_axis(Axis(0)).to_owned(), noise_pred_text.insert_axis(Axis(0)).to_owned());
-				noise_pred = &noise_pred_uncond + options.guidance_scale * (noise_pred_text - &noise_pred_uncond);
-			}
-
-			let scheduler_output = scheduler.step(noise_pred.view(), *t, latents.view(), &mut rng);
-			latents = scheduler_output.prev_sample().to_owned();
-
-			if let Some(callback) = options.callback.as_ref() {
-				if i == timesteps.len() - 1 || ((i + 1) > num_warmup_steps && (i + 1) % S::order() == 0) {
-					let keep_going = match callback {
-						StableDiffusionCallback::Progress { frequency, cb } if i % frequency == 0 => cb(i, t.to_f32().unwrap()),
-						StableDiffusionCallback::Latents { frequency, cb } if i % frequency == 0 => cb(i, t.to_f32().unwrap(), latents.clone()),
-						StableDiffusionCallback::Decoded { frequency, cb } if i != 0 && i % frequency == 0 => {
-							cb(i, t.to_f32().unwrap(), self.decode_latents(latents.clone())?)
-						}
-						StableDiffusionCallback::ApproximateDecoded { frequency, cb } if i != 0 && i % frequency == 0 => {
-							cb(i, t.to_f32().unwrap(), self.approximate_decode_latents(latents.clone())?)
-						}
-						_ => true
-					};
-					if !keep_going {
-						break;
-					}
-				}
-			}
-		}
-
-		self.decode_latents(latents)
+		let mut new_options = options;
+		new_options.positive_prompt = prompt.into();
+		new_options.run(self, scheduler)
 	}
 }

--- a/src/pipelines/stable_diffusion/impl_txt2img.rs
+++ b/src/pipelines/stable_diffusion/impl_txt2img.rs
@@ -25,6 +25,7 @@ impl Default for StableDiffusionTxt2ImgOptions {
 	}
 }
 
+// builder for options
 impl StableDiffusionTxt2ImgOptions {
 	///  Set the size of the image. **Must be divisible by 8.**
 	pub fn with_size(self, height: u32, width: u32) -> OrtResult<Self> {
@@ -67,22 +68,21 @@ impl StableDiffusionTxt2ImgOptions {
 		self.negative_prompt = negative_prompt.map(|p| p.into());
 		self
 	}
-
 	/// Set the seed to use when first generating noise. The same seed with the same scheduler, prompt, & guidance
 	pub fn with_seed(mut self, seed: u64) -> Self {
 		self.seed = Some(seed);
 		self
 	}
+	/// Set the scale of the guidance. Higher values will result in more guidance, lower values will result in less.
 	pub fn with_guidance_scale(mut self, guidance_scale: f32) -> Self {
 		self.guidance_scale = guidance_scale;
 		self
 	}
-	/// Creates a new `StableDiffusionTxt2ImgOptions` with the default options.
-	///
-	/// # Arguments
-	///
-	/// * `frequency`: The frequency at which to call the callback, in steps.
-	/// * `callback`: The callback to call every `frequency` steps.
+}
+
+// builder for callbacks
+impl StableDiffusionTxt2ImgOptions {
+	#[doc = include_str!("callback-progress.md")]
 	pub fn callback_progress<F>(mut self, frequency: usize, callback: F) -> Self
 	where
 		F: Fn(usize, f32) -> bool + 'static
@@ -90,6 +90,7 @@ impl StableDiffusionTxt2ImgOptions {
 		self.callback = Some(StableDiffusionCallback::Progress { frequency, cb: Box::new(callback) });
 		self
 	}
+	#[doc = include_str!("callback-latents.md")]
 	pub fn callback_latents<F>(mut self, frequency: usize, callback: F) -> Self
 	where
 		F: Fn(usize, f32, Array4<f32>) -> bool + 'static
@@ -97,6 +98,7 @@ impl StableDiffusionTxt2ImgOptions {
 		self.callback = Some(StableDiffusionCallback::Latents { frequency, cb: Box::new(callback) });
 		self
 	}
+	#[doc = include_str!("callback-decode-image.md")]
 	pub fn callback_decoded<F>(mut self, frequency: usize, callback: F) -> Self
 	where
 		F: Fn(usize, f32, Vec<DynamicImage>) -> bool + 'static
@@ -112,6 +114,9 @@ impl StableDiffusionTxt2ImgOptions {
 		self.callback = Some(StableDiffusionCallback::ApproximateDecoded { frequency, cb: Box::new(callback) });
 		self
 	}
+}
+
+impl StableDiffusionTxt2ImgOptions {
 	/// Generates images from given text prompt(s). Returns a vector of [`image::DynamicImage`]s, using float32 buffers.
 	/// In most cases, you'll want to convert the images into RGB8 via `img.clone().into_rgb8().`
 	///

--- a/src/pipelines/stable_diffusion/impl_txt2img.rs
+++ b/src/pipelines/stable_diffusion/impl_txt2img.rs
@@ -8,39 +8,7 @@ use ort::{OrtError, OrtResult};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
-use crate::{DiffusionScheduler, Prompt, StableDiffusionCallback, StableDiffusionPipeline};
-
-/// Options for the Stable Diffusion text-to-image pipeline.
-#[derive(Debug)]
-pub struct StableDiffusionTxt2ImgOptions {
-	/// The height of the image. **Must be divisible by 8.**
-	/// Note that higher resolution images require more VRAM.
-	pub height: u32,
-	/// The width of the image. **Must be divisible by 8.**
-	/// Note that higher resolution images require more VRAM.
-	pub width: u32,
-	/// The 'guidance scale' for classifier-free guidance. A lower guidance scale gives the model more freedom, but the
-	/// output may not match the prompt. A higher guidance scale mean the model will match the prompt(s) more strictly,
-	/// but may introduce artifacts; `7.5` is a good balance.
-	pub guidance_scale: f32,
-	/// The number of steps to take to generate the image. More steps typically yields higher quality images.
-	pub steps: usize,
-	/// An optional seed to use when first generating noise. The same seed with the same scheduler, prompt, & guidance
-	/// scale will produce the same image. If `None`, a random seed will be generated.
-	///
-	/// Seeds are not interchangable between schedulers, and **a seed from Hugging Face diffusers or AUTOMATIC1111's
-	/// web UI will *not* generate the same image** in pyke Diffusers.
-	pub seed: Option<u64>,
-	/// Prompt(s) describing what the model should generate in classifier-free guidance. Typically used to produce
-	pub positive_prompt: Prompt,
-	/// Optional prompt(s) describing what the model should **not** generate in classifier-free guidance. Typically used
-	/// to produce safe outputs, e.g. `negative_prompt: Some("gore, violence, blood".into())`. Must have the same
-	/// number of prompts as the 'positive' prompt input.
-	pub negative_prompt: Option<Prompt>,
-	/// An optional callback to call every `n` steps in the generation process. Can be used to log or display progress,
-	/// see [`StableDiffusionCallback`] for more details.
-	pub callback: Option<StableDiffusionCallback>
-}
+use crate::{DiffusionScheduler, Prompt, StableDiffusionCallback, StableDiffusionPipeline, StableDiffusionTxt2ImgOptions};
 
 impl Default for StableDiffusionTxt2ImgOptions {
 	fn default() -> Self {
@@ -58,9 +26,11 @@ impl Default for StableDiffusionTxt2ImgOptions {
 }
 
 impl StableDiffusionTxt2ImgOptions {
-	pub fn with_size(mut self, height: u32, width: u32) -> OrtResult<Self> {
+	///  Set the size of the image. **Must be divisible by 8.**
+	pub fn with_size(self, height: u32, width: u32) -> OrtResult<Self> {
 		self.with_width(width)?.with_height(height)
 	}
+	///  Set the width of the image. **Must be divisible by 8.**
 	pub fn with_width(mut self, width: u32) -> OrtResult<Self> {
 		if width % 8 != 0 || width.is_zero() {
 			Err(OrtError::DataTypeMismatch {
@@ -71,6 +41,7 @@ impl StableDiffusionTxt2ImgOptions {
 		self.width = width;
 		Ok(self)
 	}
+	///  Set the height of the image. **Must be divisible by 8.**
 	pub fn with_height(mut self, height: u32) -> OrtResult<Self> {
 		if height % 8 != 0 || height.is_zero() {
 			Err(OrtError::DataTypeMismatch {
@@ -81,17 +52,166 @@ impl StableDiffusionTxt2ImgOptions {
 		self.height = height;
 		Ok(self)
 	}
+	/// Set the number of steps to take to generate the image. More steps typically yields higher quality images.
+	pub fn with_steps(mut self, steps: usize) -> Self {
+		self.steps = steps;
+		self
+	}
+	/// Set the prompt(s) to use when generating the image. Typically used to produce classifier-free guidance.
+	pub fn with_prompts<P, N>(mut self, positive_prompt: P, negative_prompt: Option<N>) -> Self
+	where
+		P: Into<Prompt>,
+		N: Into<Prompt>
+	{
+		self.positive_prompt = positive_prompt.into();
+		self.negative_prompt = negative_prompt.map(|p| p.into());
+		self
+	}
+
+	/// Set the seed to use when first generating noise. The same seed with the same scheduler, prompt, & guidance
+	pub fn with_seed(mut self, seed: u64) -> Self {
+		self.seed = Some(seed);
+		self
+	}
+	pub fn with_guidance_scale(mut self, guidance_scale: f32) -> Self {
+		self.guidance_scale = guidance_scale;
+		self
+	}
 	/// Creates a new `StableDiffusionTxt2ImgOptions` with the default options.
 	///
 	/// # Arguments
 	///
 	/// * `frequency`: The frequency at which to call the callback, in steps.
 	/// * `callback`: The callback to call every `frequency` steps.
-	pub fn with_progress_callback<F>(mut self, frequency: usize, callback: F) -> Self
+	pub fn callback_progress<F>(mut self, frequency: usize, callback: F) -> Self
 	where
-		F: Fn(usize, f32) -> bool
+		F: Fn(usize, f32) -> bool + 'static
 	{
 		self.callback = Some(StableDiffusionCallback::Progress { frequency, cb: Box::new(callback) });
 		self
+	}
+	pub fn callback_latents<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32, Array4<f32>) -> bool + 'static
+	{
+		self.callback = Some(StableDiffusionCallback::Latents { frequency, cb: Box::new(callback) });
+		self
+	}
+	pub fn callback_decoded<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32, Vec<DynamicImage>) -> bool + 'static
+	{
+		self.callback = Some(StableDiffusionCallback::Decoded { frequency, cb: Box::new(callback) });
+		self
+	}
+	#[doc = include_str!("callback-approximate-image.md")]
+	pub fn callback_approximate<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32, Vec<DynamicImage>) -> bool + 'static
+	{
+		self.callback = Some(StableDiffusionCallback::ApproximateDecoded { frequency, cb: Box::new(callback) });
+		self
+	}
+	/// Generates images from given text prompt(s). Returns a vector of [`image::DynamicImage`]s, using float32 buffers.
+	/// In most cases, you'll want to convert the images into RGB8 via `img.clone().into_rgb8().`
+	///
+	/// `scheduler` must be a Stable Diffusion-compatible scheduler.
+	///
+	/// See [`StableDiffusionTxt2ImgOptions`] for additional configuration.
+	///
+	/// # Examples
+	///
+	/// Simple text-to-image:
+	///
+	/// ```no_run
+	/// # fn main() -> anyhow::Result<()> {
+	/// # use pyke_diffusers::{StableDiffusionPipeline, EulerDiscreteScheduler, StableDiffusionOptions, StableDiffusionTxt2ImgOptions, OrtEnvironment};
+	/// # let environment = OrtEnvironment::default().into_arc();
+	/// # let mut scheduler = EulerDiscreteScheduler::default();
+	/// let pipeline =
+	/// 	StableDiffusionPipeline::new(&environment, "./stable-diffusion-v1-5/", StableDiffusionOptions::default())?;
+	/// let txt2img = StableDiffusionTxt2ImgOptions::default().with_prompts("photo of a red fox", None);
+	///
+	/// let imgs = txt2img.run(&pipeline, &mut scheduler)?;
+	/// imgs[0].clone().into_rgb8().save("result.png")?;
+	/// # Ok(())
+	/// # }
+	/// ```
+	pub fn run<S: DiffusionScheduler>(&self, session: &StableDiffusionPipeline, scheduler: &mut S) -> anyhow::Result<Vec<DynamicImage>> {
+		let steps = self.steps;
+		let seed = self.seed.unwrap_or_else(|| rand::thread_rng().gen::<u64>());
+		let mut rng = StdRng::seed_from_u64(seed);
+
+		if self.height % 8 != 0 || self.width % 8 != 0 {
+			anyhow::bail!("`width` ({}) and `height` ({}) must be divisible by 8 for Stable Diffusion", self.width, self.height);
+		}
+
+		let prompt = self.positive_prompt.clone();
+		let batch_size = prompt.len();
+
+		let do_classifier_free_guidance = self.guidance_scale > 1.0;
+		let text_embeddings = session.encode_prompt(prompt, do_classifier_free_guidance, self.negative_prompt.as_ref())?;
+
+		let latents_shape = (batch_size, 4_usize, (self.height / 8) as usize, (self.width / 8) as usize);
+		let mut latents = Array4::<f32>::random_using(latents_shape, StandardNormal, &mut rng);
+
+		scheduler.set_timesteps(steps);
+		latents *= scheduler.init_noise_sigma();
+
+		let timesteps = scheduler.timesteps().to_owned();
+		let num_warmup_steps = timesteps.len() - self.steps * S::order();
+
+		for (i, t) in timesteps.to_owned().indexed_iter() {
+			let latent_model_input = if do_classifier_free_guidance {
+				concatenate![Axis(0), latents, latents]
+			} else {
+				latents.to_owned()
+			};
+			let latent_model_input = scheduler.scale_model_input(latent_model_input.view(), *t);
+
+			let latent_model_input: ArrayD<f32> = latent_model_input.into_dyn();
+			let timestep: ArrayD<f32> = Array1::from_iter([t.to_f32().unwrap()]).into_dyn();
+			let encoder_hidden_states: ArrayD<f32> = text_embeddings.clone().into_dyn();
+
+			let noise_pred = session.unet.run(vec![
+				InputTensor::from_array(latent_model_input),
+				InputTensor::from_array(timestep),
+				InputTensor::from_array(encoder_hidden_states),
+			])?;
+			let noise_pred: OrtOwnedTensor<'_, f32, IxDyn> = noise_pred[0].try_extract()?;
+			let noise_pred: Array4<f32> = noise_pred.view().to_owned().into_dimensionality()?;
+
+			let mut noise_pred: Array4<f32> = noise_pred.clone();
+			if do_classifier_free_guidance {
+				let mut noise_pred_chunks = noise_pred.axis_iter(Axis(0));
+				let (noise_pred_uncond, noise_pred_text) = (noise_pred_chunks.next().unwrap(), noise_pred_chunks.next().unwrap());
+				let (noise_pred_uncond, noise_pred_text) = (noise_pred_uncond.insert_axis(Axis(0)).to_owned(), noise_pred_text.insert_axis(Axis(0)).to_owned());
+				noise_pred = &noise_pred_uncond + self.guidance_scale * (noise_pred_text - &noise_pred_uncond);
+			}
+
+			let scheduler_output = scheduler.step(noise_pred.view(), *t, latents.view(), &mut rng);
+			latents = scheduler_output.prev_sample().to_owned();
+
+			if let Some(callback) = self.callback.as_ref() {
+				if i == timesteps.len() - 1 || ((i + 1) > num_warmup_steps && (i + 1) % S::order() == 0) {
+					let keep_going = match callback {
+						StableDiffusionCallback::Progress { frequency, cb } if i % frequency == 0 => cb(i, t.to_f32().unwrap()),
+						StableDiffusionCallback::Latents { frequency, cb } if i % frequency == 0 => cb(i, t.to_f32().unwrap(), latents.clone()),
+						StableDiffusionCallback::Decoded { frequency, cb } if i != 0 && i % frequency == 0 => {
+							cb(i, t.to_f32().unwrap(), session.decode_latents(latents.clone())?)
+						}
+						StableDiffusionCallback::ApproximateDecoded { frequency, cb } if i != 0 && i % frequency == 0 => {
+							cb(i, t.to_f32().unwrap(), session.approximate_decode_latents(latents.clone())?)
+						}
+						_ => true
+					};
+					if !keep_going {
+						break;
+					}
+				}
+			}
+		}
+
+		session.decode_latents(latents)
 	}
 }

--- a/src/pipelines/stable_diffusion/impl_txt2img.rs
+++ b/src/pipelines/stable_diffusion/impl_txt2img.rs
@@ -1,0 +1,97 @@
+use image::DynamicImage;
+use ndarray::{concatenate, Array1, Array4, ArrayD, Axis, IxDyn};
+use ndarray_rand::rand_distr::StandardNormal;
+use ndarray_rand::RandomExt;
+use num_traits::{ToPrimitive, Zero};
+use ort::tensor::{FromArray, InputTensor, OrtOwnedTensor, TensorElementDataType};
+use ort::{OrtError, OrtResult};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use crate::{DiffusionScheduler, Prompt, StableDiffusionCallback, StableDiffusionPipeline};
+
+/// Options for the Stable Diffusion text-to-image pipeline.
+#[derive(Debug)]
+pub struct StableDiffusionTxt2ImgOptions {
+	/// The height of the image. **Must be divisible by 8.**
+	/// Note that higher resolution images require more VRAM.
+	pub height: u32,
+	/// The width of the image. **Must be divisible by 8.**
+	/// Note that higher resolution images require more VRAM.
+	pub width: u32,
+	/// The 'guidance scale' for classifier-free guidance. A lower guidance scale gives the model more freedom, but the
+	/// output may not match the prompt. A higher guidance scale mean the model will match the prompt(s) more strictly,
+	/// but may introduce artifacts; `7.5` is a good balance.
+	pub guidance_scale: f32,
+	/// The number of steps to take to generate the image. More steps typically yields higher quality images.
+	pub steps: usize,
+	/// An optional seed to use when first generating noise. The same seed with the same scheduler, prompt, & guidance
+	/// scale will produce the same image. If `None`, a random seed will be generated.
+	///
+	/// Seeds are not interchangable between schedulers, and **a seed from Hugging Face diffusers or AUTOMATIC1111's
+	/// web UI will *not* generate the same image** in pyke Diffusers.
+	pub seed: Option<u64>,
+	/// Prompt(s) describing what the model should generate in classifier-free guidance. Typically used to produce
+	pub positive_prompt: Prompt,
+	/// Optional prompt(s) describing what the model should **not** generate in classifier-free guidance. Typically used
+	/// to produce safe outputs, e.g. `negative_prompt: Some("gore, violence, blood".into())`. Must have the same
+	/// number of prompts as the 'positive' prompt input.
+	pub negative_prompt: Option<Prompt>,
+	/// An optional callback to call every `n` steps in the generation process. Can be used to log or display progress,
+	/// see [`StableDiffusionCallback`] for more details.
+	pub callback: Option<StableDiffusionCallback>
+}
+
+impl Default for StableDiffusionTxt2ImgOptions {
+	fn default() -> Self {
+		Self {
+			height: 512,
+			width: 512,
+			guidance_scale: 7.5,
+			steps: 50,
+			seed: None,
+			positive_prompt: Default::default(),
+			negative_prompt: None,
+			callback: None
+		}
+	}
+}
+
+impl StableDiffusionTxt2ImgOptions {
+	pub fn with_size(mut self, height: u32, width: u32) -> OrtResult<Self> {
+		self.with_width(width)?.with_height(height)
+	}
+	pub fn with_width(mut self, width: u32) -> OrtResult<Self> {
+		if width % 8 != 0 || width.is_zero() {
+			Err(OrtError::DataTypeMismatch {
+				actual: TensorElementDataType::Float32,
+				requested: TensorElementDataType::Float32
+			})?
+		}
+		self.width = width;
+		Ok(self)
+	}
+	pub fn with_height(mut self, height: u32) -> OrtResult<Self> {
+		if height % 8 != 0 || height.is_zero() {
+			Err(OrtError::DataTypeMismatch {
+				actual: TensorElementDataType::Float32,
+				requested: TensorElementDataType::Float32
+			})?
+		}
+		self.height = height;
+		Ok(self)
+	}
+	/// Creates a new `StableDiffusionTxt2ImgOptions` with the default options.
+	///
+	/// # Arguments
+	///
+	/// * `frequency`: The frequency at which to call the callback, in steps.
+	/// * `callback`: The callback to call every `frequency` steps.
+	pub fn with_progress_callback<F>(mut self, frequency: usize, callback: F) -> Self
+	where
+		F: Fn(usize, f32) -> bool
+	{
+		self.callback = Some(StableDiffusionCallback::Progress { frequency, cb: Box::new(callback) });
+		self
+	}
+}

--- a/src/pipelines/stable_diffusion/mod.rs
+++ b/src/pipelines/stable_diffusion/mod.rs
@@ -22,7 +22,9 @@ use crate::{DiffusionDeviceControl, Prompt};
 pub(crate) mod lpw;
 
 mod impl_main;
+mod impl_txt2img;
 pub use self::impl_main::*;
+pub use self::impl_txt2img::StableDiffusionTxt2ImgOptions;
 mod impl_memory_optimized;
 pub use self::impl_memory_optimized::*;
 
@@ -119,49 +121,5 @@ pub enum StableDiffusionCallback {
 impl Debug for StableDiffusionCallback {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str("<StableDiffusionCallback>")
-	}
-}
-
-/// Options for the Stable Diffusion text-to-image pipeline.
-#[derive(Debug)]
-pub struct StableDiffusionTxt2ImgOptions {
-	/// The height of the image. **Must be divisible by 8.**
-	/// Note that higher resolution images require more VRAM.
-	pub height: u32,
-	/// The width of the image. **Must be divisible by 8.**
-	/// Note that higher resolution images require more VRAM.
-	pub width: u32,
-	/// The 'guidance scale' for classifier-free guidance. A lower guidance scale gives the model more freedom, but the
-	/// output may not match the prompt. A higher guidance scale mean the model will match the prompt(s) more strictly,
-	/// but may introduce artifacts; `7.5` is a good balance.
-	pub guidance_scale: f32,
-	/// The number of steps to take to generate the image. More steps typically yields higher quality images.
-	pub steps: usize,
-	/// An optional seed to use when first generating noise. The same seed with the same scheduler, prompt, & guidance
-	/// scale will produce the same image. If `None`, a random seed will be generated.
-	///
-	/// Seeds are not interchangable between schedulers, and **a seed from Hugging Face diffusers or AUTOMATIC1111's
-	/// web UI will *not* generate the same image** in pyke Diffusers.
-	pub seed: Option<u64>,
-	/// Optional prompt(s) describing what the model should **not** generate in classifier-free guidance. Typically used
-	/// to produce safe outputs, e.g. `negative_prompt: Some("gore, violence, blood".into())`. Must have the same
-	/// number of prompts as the 'positive' prompt input.
-	pub negative_prompt: Option<Prompt>,
-	/// An optional callback to call every `n` steps in the generation process. Can be used to log or display progress,
-	/// see [`StableDiffusionCallback`] for more details.
-	pub callback: Option<StableDiffusionCallback>
-}
-
-impl Default for StableDiffusionTxt2ImgOptions {
-	fn default() -> Self {
-		Self {
-			height: 512,
-			width: 512,
-			guidance_scale: 7.5,
-			steps: 50,
-			seed: None,
-			negative_prompt: None,
-			callback: None
-		}
 	}
 }


### PR DESCRIPTION
- Use a unified builder pattern to describe interfaces
- `*Options` can be reused now
- Share some docs across methods